### PR TITLE
fix orphaned processes in ivDiag

### DIFF
--- a/R/ivDiag.R
+++ b/R/ivDiag.R
@@ -161,6 +161,7 @@ ivDiag <- function(
       # register
       cl.parallel <- future::makeClusterPSOCK(cores, verbose = FALSE)
       doParallel::registerDoParallel(cl.parallel)
+      on.exit(parallel::stopCluster(cl.parallel))
       expfun <- c("OLS", "IV", "formula_lfe")
       boot.out <- foreach::foreach(
         i = 1:nboots, .combine = rbind, .inorder = FALSE,
@@ -169,7 +170,7 @@ ivDiag <- function(
       ) %dopar% {
         return(one.boot())
       }
-      doParallel::stopImplicitCluster()
+      parallel::stopCluster(cl.parallel)
     }
     ##############################
     # post-bootstrap processing
@@ -202,7 +203,7 @@ ivDiag <- function(
 
     # timing
     t1 <- Sys.time() - t0
-    message("Bootstrap took", sprintf("%.3f", t1), "sec.\n")
+    message("Bootstrap took ", sprintf("%.3f", t1), " sec.\n")
 
     ## Bootstrap outputs
     # OLS


### PR DESCRIPTION
I don't know enough about the internals of doParallel, parallel, and foreach to understand why this works. I also haven't tested this on the whole package or on other OS's. I don't know why `AR_test` doesn't need a similar modification. But this fixes the orphaned process problem for me. Yes, for some reason, both the `on.exit` on line 164 and `stopCluster` on line 173 are needed. And `stopImplicitCluster` did not work for me.

fixes #11 